### PR TITLE
Rename mcpserver package to extension, remove *mcp.Server field

### DIFF
--- a/go/sdk/README.md
+++ b/go/sdk/README.md
@@ -13,11 +13,11 @@ mcpServer := mcp.NewServer(&mcp.Implementation{
     Version: "0.1.0",
 }, nil)
 
-// Wrap with interceptor support.
-srv := mcpserver.NewServer(mcpServer)
+// Create an extension and register interceptors.
+ext := extension.New()
 
 // Register a validator that blocks dangerous tool calls.
-srv.AddInterceptor(&interceptors.Validator{
+ext.AddInterceptor(&interceptors.Validator{
     Metadata: interceptors.Metadata{
         Name: "block-dangerous",
         Hook: interceptors.Hook{
@@ -35,11 +35,12 @@ srv.AddInterceptor(&interceptors.Validator{
     },
 })
 
-// Create a chain and install middleware for automatic execution.
-chain, err := srv.LocalChain(ctx)
+// Install on the server and create a chain for middleware.
+ext.Install(mcpServer)
+chain, err := ext.LocalChain(ctx, mcpServer)
 mcpServer.AddReceivingMiddleware(gomiddleware.Middleware(chain))
 
-srv.Run(context.Background(), &mcp.StdioTransport{})
+mcpServer.Run(context.Background(), &mcp.StdioTransport{})
 ```
 
 See [`examples/`](examples/) for complete working examples.

--- a/go/sdk/doc/DESIGN.md
+++ b/go/sdk/doc/DESIGN.md
@@ -5,9 +5,10 @@
 The Go SDK follows the SEP execution model where interceptors are
 first-class MCP primitives:
 
-1. **Interceptor Server** (`mcpserver.Server`) — wraps an `mcp.Server`,
-   registers interceptors, and exposes them via `interceptors/list` and
-   `interceptor/invoke` JSON-RPC methods.
+1. **Interceptor Extension** (`extension.Extension`) — registers
+   interceptors and installs them on one or more `mcp.Server` instances,
+   exposing them via `interceptors/list` and `interceptor/invoke` JSON-RPC
+   methods.
 2. **Chain** (`chain.Chain`) — the SDK-level orchestrator in the
    `interceptors/chain` sub-package. It holds `ChainEntry` objects
    (interceptor descriptor + MCP client session) and invokes interceptors
@@ -31,8 +32,8 @@ Transport (SSE / stdio / HTTP)
 
 ## LocalChain: In-Memory Transport
 
-`Server.LocalChain(ctx)` creates a chain connected to the server via
-in-memory transport. Under the hood it:
+`Extension.LocalChain(ctx, server)` creates a chain connected to the given
+server via in-memory transport. Under the hood it:
 
 1. Creates an `InMemoryTransport` pair via `mcp.NewInMemoryTransports()`
 2. Connects the server side via `mcp.Server.Connect(ctx, serverTransport)`
@@ -206,11 +207,11 @@ Response-phase validators see the post-mutation payload.
 | `chain.go` | `Chain`, `ChainEntry`, `ExecutionParams`, `ExecutionResult`, `NewChain`, `AddMCPServer`, `Execute`; filtering, sorting, parallel validation, sequential mutation, trust-boundary ordering |
 | `result.go` | Chain result types: ChainStatus, AbortType, AbortInfo, ValidationSummary |
 
-### `interceptors/mcpserver/` — MCP server integration
+### `interceptors/extension/` — MCP server integration
 
 | File | Responsibility |
 |------|---------------|
-| `server.go` | `Server` wrapper, interceptor registry, `LocalChain`, capability declaration, `NewStreamableHTTPHandler` |
+| `server.go` | `Extension`, interceptor management, `Install`, `LocalChain`, capability declaration |
 | `rpc.go` | `handleList` and `handleInvoke` JSON-RPC method handlers |
 | `events.go` | Event name constants for standard MCP methods |
 

--- a/go/sdk/examples/mutator/main.go
+++ b/go/sdk/examples/mutator/main.go
@@ -15,8 +15,8 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors"
+	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors/extension"
 	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors/integrations/gomiddleware"
-	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors/mcpserver"
 )
 
 func main() {
@@ -73,13 +73,14 @@ func main() {
 		},
 	}
 
-	// Create the interceptor server (registers interceptors as discoverable
+	// Create the interceptor extension (registers interceptors as discoverable
 	// resources via interceptors/list and interceptor/invoke).
-	srv := mcpserver.NewServer(mcpServer)
-	srv.AddInterceptor(m)
+	ext := extension.New()
+	ext.AddInterceptor(m)
+	ext.Install(mcpServer)
 
 	// Create a chain connected via in-memory transport.
-	chain, err := srv.LocalChain(context.Background())
+	chain, err := ext.LocalChain(context.Background(), mcpServer)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -101,7 +102,10 @@ func main() {
 		),
 	)
 
-	handler := mcpserver.NewStreamableHTTPHandler(srv, nil)
+	handler := mcp.NewStreamableHTTPHandler(
+		func(r *http.Request) *mcp.Server { return mcpServer },
+		nil,
+	)
 	log.Println("listening on :8080")
 	if err := http.ListenAndServe(":8080", handler); err != nil {
 		log.Fatal(err)

--- a/go/sdk/examples/validator/main.go
+++ b/go/sdk/examples/validator/main.go
@@ -15,8 +15,8 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors"
+	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors/extension"
 	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors/integrations/gomiddleware"
-	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors/mcpserver"
 )
 
 func main() {
@@ -70,13 +70,14 @@ func main() {
 		},
 	}
 
-	// Create the interceptor server (registers interceptors as discoverable
+	// Create the interceptor extension (registers interceptors as discoverable
 	// resources via interceptors/list and interceptor/invoke).
-	srv := mcpserver.NewServer(mcpServer)
-	srv.AddInterceptor(v)
+	ext := extension.New()
+	ext.AddInterceptor(v)
+	ext.Install(mcpServer)
 
 	// Create a chain connected via in-memory transport.
-	chain, err := srv.LocalChain(context.Background())
+	chain, err := ext.LocalChain(context.Background(), mcpServer)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -98,7 +99,10 @@ func main() {
 		),
 	)
 
-	handler := mcpserver.NewStreamableHTTPHandler(srv, nil)
+	handler := mcp.NewStreamableHTTPHandler(
+		func(r *http.Request) *mcp.Server { return mcpServer },
+		nil,
+	)
 	log.Println("listening on :8080")
 	if err := http.ListenAndServe(":8080", handler); err != nil {
 		log.Fatal(err)

--- a/go/sdk/interceptors/chain/doc.go
+++ b/go/sdk/interceptors/chain/doc.go
@@ -32,8 +32,8 @@
 //	    gomiddleware.Middleware(chain),
 //	)
 //
-// For convenience, [mcpserver.Server.LocalChain] creates a chain
+// For convenience, [extension.Extension.LocalChain] creates a chain
 // pre-configured with a local in-process MCP server:
 //
-//	chain, err := srv.LocalChain(ctx)
+//	chain, err := ext.LocalChain(ctx, mcpServer)
 package chain

--- a/go/sdk/interceptors/doc.go
+++ b/go/sdk/interceptors/doc.go
@@ -10,20 +10,21 @@
 // This package is transport-agnostic — it has no dependency on the
 // MCP SDK's server or client types. The chain orchestrator lives in
 // the [interceptors/chain] sub-package, MCP server integration in
-// [interceptors/mcpserver], and middleware in
+// [interceptors/extension], and middleware in
 // [interceptors/integrations/gomiddleware].
 //
 // # Usage with MCP
 //
-// Create an interceptor [mcpserver.Server], register interceptors,
-// then use [mcpserver.Server.LocalChain] to get a chain for
-// middleware:
+// Create an [extension.Extension], register interceptors, install on
+// an [mcp.Server], then use [extension.Extension.LocalChain] to get a
+// chain for middleware:
 //
-//	srv := mcpserver.NewServer(mcpServer)
-//	srv.AddInterceptor(myValidator)
-//	srv.AddInterceptor(myMutator)
+//	ext := extension.New()
+//	ext.AddInterceptor(myValidator)
+//	ext.AddInterceptor(myMutator)
+//	ext.Install(mcpServer)
 //
-//	chain, err := srv.LocalChain(ctx)
+//	chain, err := ext.LocalChain(ctx, mcpServer)
 //	mcpServer.AddReceivingMiddleware(
 //	    gomiddleware.Middleware(chain),
 //	)

--- a/go/sdk/interceptors/extension/doc.go
+++ b/go/sdk/interceptors/extension/doc.go
@@ -2,30 +2,30 @@
 // Use of this source code is governed by an Apache-2.0
 // license that can be found in the LICENSE file.
 
-// Package mcpserver registers interceptors as first-class MCP
-// primitives. Adding an interceptor to the server makes it
+// Package extension registers interceptors as first-class MCP
+// primitives. Adding an interceptor to the extension makes it
 // discoverable via "interceptors/list" and invocable via
 // "interceptor/invoke", so any MCP client — local or remote — can
 // discover and call interceptors using standard JSON-RPC.
 //
 // # Getting Started
 //
-// Wrap an existing [mcp.Server] with [NewServer] and register
-// interceptors:
+// Create an [Extension], register interceptors, and install on an
+// [mcp.Server]:
 //
-//	srv := mcpserver.NewServer(mcpServer, mcpserver.WithLogger(logger))
-//	srv.AddInterceptor(myValidator)
-//	srv.AddInterceptor(myMutator)
-//	srv.Run(ctx, transport)
+//	ext := extension.New(extension.WithLogger(logger))
+//	ext.AddInterceptor(myValidator)
+//	ext.AddInterceptor(myMutator)
+//	ext.Install(mcpServer)
 //
 // At this point any connected MCP client can call interceptors/list
 // and interceptor/invoke.
 //
-// For convenience, [Server.LocalChain] creates a [chain.Chain] wired
+// For convenience, [Extension.LocalChain] creates a [chain.Chain] wired
 // to the server over an in-memory transport, ready for use with the
 // gomiddleware package:
 //
-//	chain, err := srv.LocalChain(ctx)
+//	chain, err := ext.LocalChain(ctx, mcpServer)
 //	mcpServer.AddReceivingMiddleware(
 //	    gomiddleware.Middleware(chain,
 //	        gomiddleware.WithContextProvider(myProvider),
@@ -34,7 +34,7 @@
 //
 // # JSON-RPC Methods
 //
-// The server registers two JSON-RPC methods:
+// The extension installs two JSON-RPC methods on the server:
 //
 //   - "interceptors/list": Returns all registered interceptors,
 //     optionally filtered by event name.
@@ -43,10 +43,13 @@
 //
 // # Transports
 //
-// The server works with any transport supported by the go-sdk.
-// For stdio, use [Server.Run]. For HTTP, use
-// [NewStreamableHTTPHandler]:
+// Users interact with the [mcp.Server] directly for transport
+// configuration. For stdio, use [mcp.Server.Run]. For HTTP, use
+// [mcp.NewStreamableHTTPHandler]:
 //
-//	handler := mcpserver.NewStreamableHTTPHandler(srv, nil)
+//	handler := mcp.NewStreamableHTTPHandler(
+//	    func(r *http.Request) *mcp.Server { return mcpServer },
+//	    nil,
+//	)
 //	http.ListenAndServe(":8080", handler)
-package mcpserver
+package extension

--- a/go/sdk/interceptors/extension/rpc.go
+++ b/go/sdk/interceptors/extension/rpc.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an Apache-2.0
 // license that can be found in the LICENSE file.
 
-package mcpserver
+package extension
 
 import (
 	"context"
@@ -19,7 +19,7 @@ import (
 
 // handleList implements the "interceptors/list" JSON-RPC method.
 // It returns all registered interceptors, optionally filtered by event.
-func (s *Server) handleList(_ context.Context, _ *mcp.ServerSession, raw json.RawMessage) (any, error) {
+func (e *Extension) handleList(_ context.Context, _ *mcp.ServerSession, raw json.RawMessage) (any, error) {
 	var params interceptors.ListParams
 	if len(raw) > 0 {
 		if err := json.Unmarshal(raw, &params); err != nil {
@@ -27,7 +27,7 @@ func (s *Server) handleList(_ context.Context, _ *mcp.ServerSession, raw json.Ra
 		}
 	}
 
-	all := s.getInterceptors()
+	all := e.getInterceptors()
 	infos := make([]interceptors.InterceptorInfo, 0, len(all))
 	for _, ri := range all {
 		if params.Event != "" && !slices.Contains(ri.GetMetadata().Hook.Events, params.Event) {
@@ -41,7 +41,7 @@ func (s *Server) handleList(_ context.Context, _ *mcp.ServerSession, raw json.Ra
 
 // handleInvoke implements the "interceptor/invoke" JSON-RPC method.
 // It invokes a single interceptor by name and returns its result.
-func (s *Server) handleInvoke(ctx context.Context, _ *mcp.ServerSession, raw json.RawMessage) (any, error) {
+func (e *Extension) handleInvoke(ctx context.Context, _ *mcp.ServerSession, raw json.RawMessage) (any, error) {
 	var params interceptors.InvokeParams
 	if err := json.Unmarshal(raw, &params); err != nil {
 		return nil, err
@@ -54,7 +54,7 @@ func (s *Server) handleInvoke(ctx context.Context, _ *mcp.ServerSession, raw jso
 	}
 
 	// Look up the interceptor by name.
-	i := s.findByName(params.Name)
+	i := e.findByName(params.Name)
 	if i == nil {
 		return nil, &jsonrpc.Error{
 			Code:    jsonrpc.CodeInvalidParams,

--- a/go/sdk/interceptors/extension/rpc_test.go
+++ b/go/sdk/interceptors/extension/rpc_test.go
@@ -1,4 +1,4 @@
-package mcpserver_test
+package extension_test
 
 import (
 	"context"

--- a/go/sdk/interceptors/extension/server.go
+++ b/go/sdk/interceptors/extension/server.go
@@ -2,12 +2,11 @@
 // Use of this source code is governed by an Apache-2.0
 // license that can be found in the LICENSE file.
 
-package mcpserver
+package extension
 
 import (
 	"context"
 	"log/slog"
-	"net/http"
 	"sync"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -19,57 +18,57 @@ import (
 // extensionID is the capability key used in Capabilities.Experimental
 const extensionID = "io.modelcontextprotocol/interceptors"
 
-// ServerOption configures a Server.
-type ServerOption func(*Server)
+// Option configures an Extension.
+type Option func(*Extension)
 
 // WithLogger sets the logger for interceptor chain execution.
 // If not set, slog.Default() is used.
-func WithLogger(l *slog.Logger) ServerOption {
-	return func(s *Server) {
-		s.logger = l
+func WithLogger(l *slog.Logger) Option {
+	return func(e *Extension) {
+		e.logger = l
 	}
 }
 
-// Server wraps an *mcp.Server with interceptor support. Interceptors are
-// registered as first-class MCP resources discoverable via the
-// "interceptors/list" JSON-RPC method and invocable via
-// "interceptor/invoke".
-type Server struct {
-	inner        *mcp.Server
+// Extension manages interceptors and can install them on one or more
+// *mcp.Server instances. Interceptors are registered as first-class
+// MCP resources discoverable via the "interceptors/list" JSON-RPC
+// method and invocable via "interceptor/invoke".
+//
+// Extension is a pure interceptor container — it does not hold a
+// reference to any particular server. Call [Extension.Install] to
+// register the JSON-RPC methods and capability middleware on a server.
+type Extension struct {
 	mu           sync.RWMutex
 	interceptors []interceptors.Interceptor
 	logger       *slog.Logger
 }
 
-// NewServer creates a new interceptor server wrapping the given mcp.Server.
-// It registers the "interceptors/list" and "interceptor/invoke" JSON-RPC
-// methods and installs a receiving middleware to enrich the initialize
-// response with interceptor capabilities.
-func NewServer(server *mcp.Server, opts ...ServerOption) *Server {
-	s := &Server{
-		inner: server,
-	}
+// New creates a new interceptor Extension.
+func New(opts ...Option) *Extension {
+	e := &Extension{}
 	for _, opt := range opts {
-		opt(s)
+		opt(e)
 	}
-	if s.logger == nil {
-		s.logger = slog.Default()
+	if e.logger == nil {
+		e.logger = slog.Default()
 	}
+	return e
+}
 
-	// Register JSON-RPC methods for interceptor discovery and invocation.
-	server.AddCustomMethod(interceptors.MethodList, s.handleList)
-	server.AddCustomMethod(interceptors.MethodInvoke, s.handleInvoke)
-
-	// Install lightweight middleware to enrich initialize responses.
-	server.AddReceivingMiddleware(s.initMiddleware())
-
-	return s
+// Install registers the "interceptors/list" and "interceptor/invoke"
+// JSON-RPC methods and installs a receiving middleware to enrich the
+// initialize response with interceptor capabilities on the given
+// server. It can be called on multiple servers.
+func (e *Extension) Install(server *mcp.Server) {
+	server.AddCustomMethod(interceptors.MethodList, e.handleList)
+	server.AddCustomMethod(interceptors.MethodInvoke, e.handleInvoke)
+	server.AddReceivingMiddleware(e.initMiddleware())
 }
 
 // AddInterceptor registers an interceptor. It panics if the interceptor
 // has a nil handler. Except for the panic it is safe to call while the server is running,
 // returns the receiver for chaining.
-func (s *Server) AddInterceptor(i interceptors.Interceptor) *Server {
+func (e *Extension) AddInterceptor(i interceptors.Interceptor) *Extension {
 	switch v := i.(type) {
 	case *interceptors.Validator:
 		if v.Handler == nil {
@@ -80,17 +79,17 @@ func (s *Server) AddInterceptor(i interceptors.Interceptor) *Server {
 			panic("interceptors: mutator " + v.Name + " has nil handler")
 		}
 	}
-	s.mu.Lock()
-	s.interceptors = append(s.interceptors, i)
-	s.mu.Unlock()
-	return s
+	e.mu.Lock()
+	e.interceptors = append(e.interceptors, i)
+	e.mu.Unlock()
+	return e
 }
 
 // findByName returns the interceptor with the given name, or nil if not found.
-func (s *Server) findByName(name string) interceptors.Interceptor {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	for _, i := range s.interceptors {
+func (e *Extension) findByName(name string) interceptors.Interceptor {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	for _, i := range e.interceptors {
 		if i.GetMetadata().Name == name {
 			return i
 		}
@@ -99,26 +98,26 @@ func (s *Server) findByName(name string) interceptors.Interceptor {
 }
 
 // getInterceptors returns a snapshot of the current interceptor list.
-func (s *Server) getInterceptors() []interceptors.Interceptor {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	cp := make([]interceptors.Interceptor, len(s.interceptors))
-	copy(cp, s.interceptors)
+func (e *Extension) getInterceptors() []interceptors.Interceptor {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	cp := make([]interceptors.Interceptor, len(e.interceptors))
+	copy(cp, e.interceptors)
 	return cp
 }
 
-// LocalChain creates an interceptor Chain connected to this server
+// LocalChain creates an interceptor Chain connected to the given server
 // via in-memory transport. This is the primary way to get a Chain
 // for use with middleware.
 //
 // The returned chain discovers interceptors from the server via
 // interceptors/list and invokes them via interceptor/invoke, exactly
 // as a remote chain would — but over an in-memory transport.
-func (s *Server) LocalChain(ctx context.Context) (*chain.Chain, error) {
+func (e *Extension) LocalChain(ctx context.Context, server *mcp.Server) (*chain.Chain, error) {
 	serverTransport, clientTransport := mcp.NewInMemoryTransports()
 
 	// Connect the server side.
-	ss, err := s.inner.Connect(ctx, serverTransport, nil)
+	ss, err := server.Connect(ctx, serverTransport, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +133,7 @@ func (s *Server) LocalChain(ctx context.Context) (*chain.Chain, error) {
 		return nil, err
 	}
 
-	ch := chain.NewChain(chain.WithChainLogger(s.logger))
+	ch := chain.NewChain(chain.WithChainLogger(e.logger))
 	if err := ch.AddMCPServer(ctx, cs); err != nil {
 		cs.Close()
 		ss.Close()
@@ -144,25 +143,9 @@ func (s *Server) LocalChain(ctx context.Context) (*chain.Chain, error) {
 	return ch, nil
 }
 
-// MCPServer returns the underlying *mcp.Server. This is useful when
-// composing with other extensions (e.g., variants):
-//
-//	is := mcpserver.NewServer(mcpServer)
-//	is.AddInterceptor(myValidator)
-//	vs.WithVariant(variant, is.MCPServer(), 0)
-func (s *Server) MCPServer() *mcp.Server {
-	return s.inner
-}
-
-// Run delegates to the inner server's Run method. Convenience for standalone
-// use (e.g., stdio).
-func (s *Server) Run(ctx context.Context, t mcp.Transport) error {
-	return s.inner.Run(ctx, t)
-}
-
 // initMiddleware returns a lightweight mcp.Middleware that enriches the
 // initialize response with interceptor capability metadata.
-func (s *Server) initMiddleware() mcp.Middleware {
+func (e *Extension) initMiddleware() mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
 			result, err := next(ctx, method, req)
@@ -170,7 +153,7 @@ func (s *Server) initMiddleware() mcp.Middleware {
 				return nil, err
 			}
 			if method == "initialize" {
-				return s.enrichInitResult(result)
+				return e.enrichInitResult(result)
 			}
 			return result, nil
 		}
@@ -181,7 +164,7 @@ func (s *Server) initMiddleware() mcp.Middleware {
 // InitializeResult, following the same pattern as the variants extension.
 // The capability is declared under Capabilities.Experimental so it works
 // without upstream go-sdk changes.
-func (s *Server) enrichInitResult(result mcp.Result) (mcp.Result, error) {
+func (e *Extension) enrichInitResult(result mcp.Result) (mcp.Result, error) {
 	initResult, ok := result.(*mcp.InitializeResult)
 	if !ok {
 		return result, nil
@@ -194,17 +177,17 @@ func (s *Server) enrichInitResult(result mcp.Result) (mcp.Result, error) {
 		initResult.Capabilities.Experimental = make(map[string]any)
 	}
 
-	all := s.getInterceptors()
+	all := e.getInterceptors()
 	supportedEvents := map[string]bool{}
 	for _, ri := range all {
-		for _, e := range ri.GetMetadata().Hook.Events {
-			supportedEvents[e] = true
+		for _, ev := range ri.GetMetadata().Hook.Events {
+			supportedEvents[ev] = true
 		}
 	}
 
 	events := make([]string, 0, len(supportedEvents))
-	for e := range supportedEvents {
-		events = append(events, e)
+	for ev := range supportedEvents {
+		events = append(events, ev)
 	}
 
 	initResult.Capabilities.Experimental[extensionID] = map[string]any{
@@ -212,21 +195,4 @@ func (s *Server) enrichInitResult(result mcp.Result) (mcp.Result, error) {
 	}
 
 	return initResult, nil
-}
-
-// NewStreamableHTTPHandler returns a new [mcp.StreamableHTTPHandler] for
-// serving multiple concurrent clients over HTTP. It mirrors
-// [mcp.NewStreamableHTTPHandler].
-//
-//	handler := mcpserver.NewStreamableHTTPHandler(srv, nil)
-//	http.ListenAndServe(":8080", handler)
-func NewStreamableHTTPHandler(s *Server, opts *mcp.StreamableHTTPOptions) *mcp.StreamableHTTPHandler {
-	if s == nil {
-		panic("mcpserver: nil Server")
-	}
-	srv := s.MCPServer()
-	return mcp.NewStreamableHTTPHandler(
-		func(r *http.Request) *mcp.Server { return srv },
-		opts,
-	)
 }

--- a/go/sdk/interceptors/extension/server_integration_test.go
+++ b/go/sdk/interceptors/extension/server_integration_test.go
@@ -1,4 +1,4 @@
-package mcpserver_test
+package extension_test
 
 import (
 	"context"

--- a/go/sdk/interceptors/extension/testharness_test.go
+++ b/go/sdk/interceptors/extension/testharness_test.go
@@ -1,9 +1,10 @@
-package mcpserver_test
+package extension_test
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -12,8 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors"
+	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors/extension"
 	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors/integrations/gomiddleware"
-	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors/mcpserver"
 )
 
 // --- Server setup ---
@@ -42,19 +43,23 @@ func setupWithTools(t *testing.T, tools []testTool, is ...interceptors.Intercept
 		mcpServer.AddTool(tool.tool, tool.handler)
 	}
 
-	srv := mcpserver.NewServer(mcpServer)
+	ext := extension.New()
 	for _, i := range is {
-		srv.AddInterceptor(i)
+		ext.AddInterceptor(i)
 	}
+	ext.Install(mcpServer)
 
 	// Create a chain via LocalChain (in-memory transport).
-	chain, err := srv.LocalChain(context.Background())
+	chain, err := ext.LocalChain(context.Background(), mcpServer)
 	require.NoError(t, err)
 
 	// Install the middleware for automatic interceptor execution.
 	mcpServer.AddReceivingMiddleware(gomiddleware.Middleware(chain))
 
-	handler := mcpserver.NewStreamableHTTPHandler(srv, nil)
+	handler := mcp.NewStreamableHTTPHandler(
+		func(r *http.Request) *mcp.Server { return mcpServer },
+		nil,
+	)
 	httpServer := httptest.NewServer(handler)
 	t.Cleanup(httpServer.Close)
 
@@ -130,7 +135,7 @@ func resultText(t *testing.T, result *mcp.CallToolResult) string {
 
 // --- RPC server setup ---
 
-// setupRPCServer creates an interceptor server with the given interceptors
+// setupRPCServer creates an interceptor extension with the given interceptors
 // and returns a connected client session. The client can call custom methods
 // via raw JSON-RPC.
 func setupRPCServer(t *testing.T, is ...interceptors.Interceptor) *mcp.ClientSession {
@@ -152,12 +157,16 @@ func setupRPCServer(t *testing.T, is ...interceptors.Interceptor) *mcp.ClientSes
 		}, nil
 	})
 
-	srv := mcpserver.NewServer(mcpServer)
+	ext := extension.New()
 	for _, i := range is {
-		srv.AddInterceptor(i)
+		ext.AddInterceptor(i)
 	}
+	ext.Install(mcpServer)
 
-	handler := mcpserver.NewStreamableHTTPHandler(srv, nil)
+	handler := mcp.NewStreamableHTTPHandler(
+		func(r *http.Request) *mcp.Server { return mcpServer },
+		nil,
+	)
 	httpServer := httptest.NewServer(handler)
 	t.Cleanup(httpServer.Close)
 

--- a/go/sdk/interceptors/integrations/gomiddleware/doc.go
+++ b/go/sdk/interceptors/integrations/gomiddleware/doc.go
@@ -16,13 +16,14 @@
 //
 // # Usage
 //
-//	// Create interceptor server (registers interceptors as resources)
-//	srv := mcpserver.NewServer(mcpServer)
-//	srv.AddInterceptor(myValidator)
-//	srv.AddInterceptor(myMutator)
+//	// Create interceptor extension (registers interceptors as resources)
+//	ext := extension.New()
+//	ext.AddInterceptor(myValidator)
+//	ext.AddInterceptor(myMutator)
+//	ext.Install(mcpServer)
 //
 //	// Create chain via in-memory transport
-//	chain, err := srv.LocalChain(ctx)
+//	chain, err := ext.LocalChain(ctx, mcpServer)
 //
 //	// Install middleware for automatic execution
 //	mcpServer.AddReceivingMiddleware(

--- a/go/sdk/interceptors/integrations/gomiddleware/middleware_test.go
+++ b/go/sdk/interceptors/integrations/gomiddleware/middleware_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -13,8 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors"
+	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors/extension"
 	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors/integrations/gomiddleware"
-	"github.com/modelcontextprotocol/ext-interceptors/go/sdk/interceptors/mcpserver"
 )
 
 // setup creates a test server with middleware installed and returns a connected client session.
@@ -36,19 +37,23 @@ func setup(t *testing.T, is ...interceptors.Interceptor) *mcp.ClientSession {
 		}, nil
 	})
 
-	srv := mcpserver.NewServer(mcpServer)
+	ext := extension.New()
 	for _, i := range is {
-		srv.AddInterceptor(i)
+		ext.AddInterceptor(i)
 	}
+	ext.Install(mcpServer)
 
 	// Create chain via LocalChain (in-memory transport).
-	chain, err := srv.LocalChain(context.Background())
+	chain, err := ext.LocalChain(context.Background(), mcpServer)
 	require.NoError(t, err)
 
 	// Install the middleware.
 	mcpServer.AddReceivingMiddleware(gomiddleware.Middleware(chain))
 
-	handler := mcpserver.NewStreamableHTTPHandler(srv, nil)
+	handler := mcp.NewStreamableHTTPHandler(
+		func(r *http.Request) *mcp.Server { return mcpServer },
+		nil,
+	)
 	httpServer := httptest.NewServer(handler)
 	t.Cleanup(httpServer.Close)
 
@@ -260,10 +265,11 @@ func TestMiddlewareWithContextProvider(t *testing.T) {
 		}, nil
 	})
 
-	srv := mcpserver.NewServer(mcpServer)
-	srv.AddInterceptor(principalCheck)
+	ext := extension.New()
+	ext.AddInterceptor(principalCheck)
+	ext.Install(mcpServer)
 
-	chain, err := srv.LocalChain(context.Background())
+	chain, err := ext.LocalChain(context.Background(), mcpServer)
 	require.NoError(t, err)
 
 	mcpServer.AddReceivingMiddleware(gomiddleware.Middleware(chain,
@@ -277,7 +283,10 @@ func TestMiddlewareWithContextProvider(t *testing.T) {
 		}),
 	))
 
-	handler := mcpserver.NewStreamableHTTPHandler(srv, nil)
+	handler := mcp.NewStreamableHTTPHandler(
+		func(r *http.Request) *mcp.Server { return mcpServer },
+		nil,
+	)
 	httpServer := httptest.NewServer(handler)
 	t.Cleanup(httpServer.Close)
 


### PR DESCRIPTION
## Summary

- Rename `interceptors/mcpserver/` → `interceptors/extension/`, replacing the `Server` wrapper with a lightweight `Extension` that can install itself on any `*mcp.Server`
- Remove the stored `*mcp.Server` field — `Extension` is now a pure interceptor container with no server reference
- Add `Install(server)` method to register JSON-RPC methods and init middleware on a given server
- Update `LocalChain(ctx)` → `LocalChain(ctx, server)` to accept the server as a parameter
- Remove `MCPServer()`, `Run()`, and `NewStreamableHTTPHandler()` wrapper methods — users interact with `mcp.Server` directly
- Update all examples, tests, and documentation to use the new API

## Why

`mcpserver.Server` pretended to *be* the server — it had `Run()`,
`NewStreamableHTTPHandler()`, etc. — but it could never cover the full
`*mcp.Server` API, so users constantly needed `MCPServer()` to unwrap it.

`Extension` doesn't pretend to be the server. It's a pure interceptor
container that can install itself on any server (or multiple servers)
on the fly. No stored server reference, no wrapping, no delegation
surface to maintain.

### Before

```go
mcpServer := mcp.NewServer(...)
srv := mcpserver.NewServer(mcpServer)
srv.AddInterceptor(v)
chain, err := srv.LocalChain(ctx)
```

### After

```go
mcpServer := mcp.NewServer(...)
ext := extension.New()
ext.AddInterceptor(v)
ext.Install(mcpServer)
chain, err := ext.LocalChain(ctx, mcpServer)
```