### PR TITLE
docs: link the Interceptors Working Group charter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This repository provides a multi-language reference implementation of the proposed interceptor extension for the Model Context Protocol (MCP), as described in [SEP-2624](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2624).
 
+**Charter:** [modelcontextprotocol.io/community/working-groups/interceptors](https://modelcontextprotocol.io/community/working-groups/interceptors) — the Interceptors Working Group's mission, scope, leadership, and active work items.
+
 
 ## Implementations
 


### PR DESCRIPTION
Adds a link to the [Interceptors Working Group charter](https://modelcontextprotocol.io/community/working-groups/interceptors) near the top of the README, following the convention used across MCP experimental extension repos (e.g. [experimental-ext-skills](https://github.com/modelcontextprotocol/experimental-ext-skills)).

The charter page documents the working group's mission, scope, leadership, and active work items — useful context for anyone landing on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)