### PR TITLE
ci: add Dependabot version-update config across SDKs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+# Dependabot version-update configuration.
+#
+# Note: security updates (CVE-driven PRs) are enabled at the repository level
+# and do NOT depend on this file — they already cover every ecosystem. This
+# config adds *scheduled version updates* ("keep dependencies current" PRs).
+#
+# Python (python/sdk) is intentionally omitted until a real Python SDK exists;
+# it is currently alpha scaffolding. Add a `pip` entry when that lands.
+version: 2
+updates:
+  # C# SDK
+  - package-ecosystem: nuget
+    directory: /csharp/sdk
+    schedule:
+      interval: weekly
+    groups:
+      dotnet:
+        patterns: ["*"]
+
+  # Go SDK
+  - package-ecosystem: gomod
+    directory: /go/sdk
+    schedule:
+      interval: weekly
+
+  # TypeScript SDK
+  - package-ecosystem: npm
+    directory: /typescript/sdk
+    schedule:
+      interval: weekly
+    groups:
+      npm:
+        patterns: ["*"]
+
+  # GitHub Actions used by CI workflows
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` enabling **scheduled version updates** for every active SDK — **C#** (`nuget`), **Go** (`gomod`), **TypeScript** (`npm`) — plus the CI **GitHub Actions**.

## Why

The repo had **no `dependabot.yml`**, so only repository-level **security updates** were running (the CVE-driven PRs like #9 and #14). Those cover all ecosystems automatically, *including* C# — but there were no routine "keep dependencies current" PRs for any language. This closes that gap and brings the C# SDK in line with the others.

## Notes for the working group

- **Security vs. version updates:** security alert PRs do not depend on this file and already apply to NuGet/C#. This PR only adds the proactive version-update stream.
- **Cadence:** `weekly` — `daily` gets noisy with this many ecosystems.
- **Grouping:** `npm` and `nuget` updates are grouped into one PR per ecosystem per week to reduce noise. Happy to split majors out if preferred.
- **Python omitted on purpose:** `python/sdk/` is currently alpha scaffolding (no real SDK yet). Add a `pip` entry when a Python SDK actually lands.

Opening this as a concrete proposal to discuss at the interceptors WG sync re: unifying dependency management across SDKs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)