### PR TITLE
Docs: Add MCP Dev Summit talk link and fix issues URL typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,4 @@ Apache License 2.0 - See LICENSE file for details
 
 - [Interceptor Framework Specification (SEP-2624)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2624) - Full specification and design details
 - [Model Context Protocol](https://modelcontextprotocol.io/specification)
+- [Interceptors for MCP: A Production-Tested Standard for Agentic Middleware](https://www.youtube.com/watch?v=YOv1d7PVi8U) - Kurt Degiorgio & Cannis Chan (Bloomberg), MCP Dev Summit North America

--- a/docs/sep.md
+++ b/docs/sep.md
@@ -7,7 +7,7 @@
 - **Sponsor**: Sambhav Kothari (@sambhav)
 - **PR**: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2624
 
-> **NOTE:** This SEP has been submitted to the main MCP repository as [SEP-2624](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2624); future review and comments happen there. This repo-local copy is the working draft maintained by the [Interceptors Working Group](https://github.com/modelcontextprotocol/experimental-ext-interceptors) and may be revised as upstream review feedback is incorporated. Additional discussion welcome via [GitHub Issues](https://github.com/modelcontextprotocol/experimental-ext-interceptros/issues) or [Discord #interceptors-wg](https://discord.com/channels/1358869848138059966/1474446054291279933).
+> **NOTE:** This SEP has been submitted to the main MCP repository as [SEP-2624](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2624); future review and comments happen there. This repo-local copy is the working draft maintained by the [Interceptors Working Group](https://github.com/modelcontextprotocol/experimental-ext-interceptors) and may be revised as upstream review feedback is incorporated. Additional discussion welcome via [GitHub Issues](https://github.com/modelcontextprotocol/experimental-ext-interceptors/issues) or [Discord #interceptors-wg](https://discord.com/channels/1358869848138059966/1474446054291279933).
 
 ## Abstract
 


### PR DESCRIPTION
Fixing and adding a couple of links

(btw @PederHP I couldn't find a video for your talk yet but please add a link if you have one.)